### PR TITLE
Delete all volumes on a found cluster

### DIFF
--- a/internal/civo/kubernetes.go
+++ b/internal/civo/kubernetes.go
@@ -37,10 +37,12 @@ func (c *Civo) NukeKubernetesClusters() error {
 		for _, volume := range clusterVolumes {
 			c.logger.Infof("found volume: name: %q - ID: %q", volume.Name, volume.ID)
 
-			if c.nameFilter != "" && !compare.ContainsIgnoreCase(volume.Name, c.nameFilter) {
-				c.logger.Warnf("skipping volume %q: name does not match filter", volume.Name)
-				continue
-			}
+			// We don't filter by volumes since Volume names are specific to the PVC
+			// that created them (so on a cluster called "foo", the PVC would be called
+			// "pvc-82d40d15-5ce2-418d-bb81-09a0349ec975").
+			// If we land in this section, it means a Kubernetes cluster was already
+			// found by matching the name filter, so we can safely delete all volumes
+			// associated with it.
 
 			if c.nuke {
 				c.logger.Infof("deleting volume %q for cluster %q", volume.Name, cluster.Name)


### PR DESCRIPTION
## Description

The train of thought is: if we filter on a cluster, we do want to delete ALL volumes *just for that cluster*. It doesn't make sense to filter those volumes too if they're not meant to stick around if the cluster who created them is gone.

The current code will find the cluster but also filter the volumes too by name. That's also not possible since Kubernetes PVC Volumes have a random ID as the name (example: `pvc-82d40d15-5ce2-418d-bb81-09a0349ec975`) so the filtered name won't even be available there. 

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
