### PR TITLE
Add SSH key deletion support. Add orphaned resources check.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,7 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - forcetypeassert
     - ginkgolinter
     - gocheckcompilerdirectives

--- a/cmd/civo.go
+++ b/cmd/civo.go
@@ -36,11 +36,11 @@ func getCivoCommand() *cobra.Command {
 	civoCmd.Flags().BoolVar(&opts.nuke, "nuke", false, "required to confirm deletion of resources")
 	civoCmd.Flags().StringVar(&opts.region, "region", "", "the civo region to clean")
 	civoCmd.Flags().StringVar(&opts.nameFilter, "name-contains", "", "if set, only resources with a name containing this string will be selected")
-	civoCmd.Flags().BoolVar(&opts.onlyOrphans, "only-orphans", false, "only delete orphaned resources")
+	civoCmd.Flags().BoolVar(&opts.onlyOrphans, "orphans-only", false, "only delete orphaned resources (only volumes, SSH keys and networks)")
 
 	// On orphaned resources, we don't want to filter by name since the
 	// filter is already that's just for the resources we want to delete
-	civoCmd.MarkFlagsMutuallyExclusive("name-contains", "only-orphans")
+	civoCmd.MarkFlagsMutuallyExclusive("name-contains", "orphans-only")
 
 	if err := civoCmd.MarkFlagRequired("region"); err != nil {
 		log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
+	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/civo/client.go
+++ b/internal/civo/client.go
@@ -72,6 +72,8 @@ func WithNameFilter(nameFilter string) Option {
 }
 
 // client is an interface for the Civo API client.
+//
+//nolint:interfacebloat // the Civo API client has many methods
 type client interface {
 	ListInstances(page int, perPage int) (*civogo.PaginatedInstanceList, error)
 	ListSSHKeys() ([]civogo.SSHKey, error)

--- a/internal/civo/client.go
+++ b/internal/civo/client.go
@@ -90,11 +90,15 @@ type client interface {
 	DeleteObjectStore(id string) (*civogo.SimpleResponse, error)
 }
 
+var _ client = &civogo.Client{}
+
 type customLogger interface {
 	Errorf(format string, v ...interface{})
 	Infof(format string, v ...interface{})
 	Warnf(format string, v ...interface{})
 }
+
+var _ customLogger = &logger.Logger{}
 
 // New creates a new Civo with the given options.
 // It returns an error if the token or region is not set, or if it fails to create the underlying Civo API client.

--- a/internal/civo/client.go
+++ b/internal/civo/client.go
@@ -11,13 +11,13 @@ import (
 
 // Civo is a client for the Civo API.
 type Civo struct {
-	client     *civogo.Client  // The underlying Civo API client.
+	client     client          // The underlying Civo API client.
 	context    context.Context // The context for API requests.
 	nuke       bool            // Whether to nuke resources.
 	region     string          // The region for API requests.
 	nameFilter string          // If set, only resources with a name containing this string will be deleted.
 	token      string          // The API token.
-	logger     *logger.Logger  // The logger instance.
+	logger     customLogger    // The logger instance.
 }
 
 // Option is a function that configures a Civo.
@@ -69,6 +69,31 @@ func WithNameFilter(nameFilter string) Option {
 		c.nameFilter = nameFilter
 		return nil
 	}
+}
+
+// client is an interface for the Civo API client.
+type client interface {
+	ListInstances(page int, perPage int) (*civogo.PaginatedInstanceList, error)
+	ListSSHKeys() ([]civogo.SSHKey, error)
+	DeleteSSHKey(id string) (*civogo.SimpleResponse, error)
+	ListVolumes() ([]civogo.Volume, error)
+	DeleteVolume(id string) (*civogo.SimpleResponse, error)
+	ListKubernetesClusters() (*civogo.PaginatedKubernetesClusters, error)
+	DeleteKubernetesCluster(id string) (*civogo.SimpleResponse, error)
+	ListVolumesForCluster(clusterID string) ([]civogo.Volume, error)
+	ListNetworks() ([]civogo.Network, error)
+	FindNetwork(search string) (*civogo.Network, error)
+	DeleteNetwork(id string) (*civogo.SimpleResponse, error)
+	ListObjectStoreCredentials() (*civogo.PaginatedObjectStoreCredentials, error)
+	DeleteObjectStoreCredential(id string) (*civogo.SimpleResponse, error)
+	ListObjectStores() (*civogo.PaginatedObjectstores, error)
+	DeleteObjectStore(id string) (*civogo.SimpleResponse, error)
+}
+
+type customLogger interface {
+	Errorf(format string, v ...interface{})
+	Infof(format string, v ...interface{})
+	Warnf(format string, v ...interface{})
 }
 
 // New creates a new Civo with the given options.

--- a/internal/civo/client_test.go
+++ b/internal/civo/client_test.go
@@ -1,0 +1,102 @@
+package civo
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/civo/civogo"
+)
+
+type mockCivoClient struct {
+	FnListInstances               func(page int, perPage int) (*civogo.PaginatedInstanceList, error)
+	FnListSSHKeys                 func() ([]civogo.SSHKey, error)
+	FnDeleteSSHKey                func(id string) (*civogo.SimpleResponse, error)
+	FnListVolumes                 func() ([]civogo.Volume, error)
+	FnDeleteVolume                func(id string) (*civogo.SimpleResponse, error)
+	FnListKubernetesClusters      func() (*civogo.PaginatedKubernetesClusters, error)
+	FnDeleteKubernetesCluster     func(id string) (*civogo.SimpleResponse, error)
+	FnListVolumesForCluster       func(clusterID string) ([]civogo.Volume, error)
+	FnListNetworks                func() ([]civogo.Network, error)
+	FnFindNetwork                 func(search string) (*civogo.Network, error)
+	FnDeleteNetwork               func(id string) (*civogo.SimpleResponse, error)
+	FnListObjectStoreCredentials  func() (*civogo.PaginatedObjectStoreCredentials, error)
+	FnDeleteObjectStoreCredential func(id string) (*civogo.SimpleResponse, error)
+	FnListObjectStores            func() (*civogo.PaginatedObjectstores, error)
+	FnDeleteObjectStore           func(id string) (*civogo.SimpleResponse, error)
+}
+
+func (m *mockCivoClient) ListInstances(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+	return m.FnListInstances(page, perPage)
+}
+
+func (m *mockCivoClient) ListSSHKeys() ([]civogo.SSHKey, error) {
+	return m.FnListSSHKeys()
+}
+
+func (m *mockCivoClient) DeleteSSHKey(id string) (*civogo.SimpleResponse, error) {
+	return m.FnDeleteSSHKey(id)
+}
+
+func (m *mockCivoClient) ListVolumes() ([]civogo.Volume, error) {
+	return m.FnListVolumes()
+}
+
+func (m *mockCivoClient) DeleteVolume(id string) (*civogo.SimpleResponse, error) {
+	return m.FnDeleteVolume(id)
+}
+
+func (m *mockCivoClient) ListKubernetesClusters() (*civogo.PaginatedKubernetesClusters, error) {
+	return m.FnListKubernetesClusters()
+}
+
+func (m *mockCivoClient) DeleteKubernetesCluster(id string) (*civogo.SimpleResponse, error) {
+	return m.FnDeleteKubernetesCluster(id)
+}
+
+func (m *mockCivoClient) ListVolumesForCluster(clusterID string) ([]civogo.Volume, error) {
+	return m.FnListVolumesForCluster(clusterID)
+}
+
+func (m *mockCivoClient) ListNetworks() ([]civogo.Network, error) {
+	return m.FnListNetworks()
+}
+
+func (m *mockCivoClient) FindNetwork(search string) (*civogo.Network, error) {
+	return m.FnFindNetwork(search)
+}
+
+func (m *mockCivoClient) DeleteNetwork(id string) (*civogo.SimpleResponse, error) {
+	return m.FnDeleteNetwork(id)
+}
+
+func (m *mockCivoClient) ListObjectStoreCredentials() (*civogo.PaginatedObjectStoreCredentials, error) {
+	return m.FnListObjectStoreCredentials()
+}
+
+func (m *mockCivoClient) DeleteObjectStoreCredential(id string) (*civogo.SimpleResponse, error) {
+	return m.FnDeleteObjectStoreCredential(id)
+}
+
+func (m *mockCivoClient) ListObjectStores() (*civogo.PaginatedObjectstores, error) {
+	return m.FnListObjectStores()
+}
+
+func (m *mockCivoClient) DeleteObjectStore(id string) (*civogo.SimpleResponse, error) {
+	return m.FnDeleteObjectStore(id)
+}
+
+type mockLogger struct {
+	output io.Writer
+}
+
+func (m *mockLogger) Infof(format string, args ...interface{}) {
+	fmt.Fprintf(m.output, "[INFO] "+format+"\n", args...)
+}
+
+func (m *mockLogger) Errorf(format string, args ...interface{}) {
+	fmt.Fprintf(m.output, "[ERROR] "+format+"\n", args...)
+}
+
+func (m *mockLogger) Warnf(format string, args ...interface{}) {
+	fmt.Fprintf(m.output, "[WARN] "+format+"\n", args...)
+}

--- a/internal/civo/kubernetes_test.go
+++ b/internal/civo/kubernetes_test.go
@@ -1,0 +1,279 @@
+package civo
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/civo/civogo"
+)
+
+func TestNukeKubernetesClusters(t *testing.T) {
+	t.Run("successfully list and delete kubernetes clusters", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListKubernetesClusters: func() (*civogo.PaginatedKubernetesClusters, error) {
+				return &civogo.PaginatedKubernetesClusters{
+					Items: []civogo.KubernetesCluster{{ID: "cluster1", Name: "test-cluster1"}},
+				}, nil
+			},
+
+			FnListVolumesForCluster: func(clusterID string) ([]civogo.Volume, error) {
+				return []civogo.Volume{{ID: "volume1", Name: "test-volume1"}}, nil
+			},
+
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+
+			FnDeleteKubernetesCluster: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+
+			FnFindNetwork: func(search string) (*civogo.Network, error) {
+				return &civogo.Network{ID: "network1", Name: "test-network1"}, nil
+			},
+
+			FnDeleteNetwork: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeKubernetesClusters()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+
+	t.Run("error listing kubernetes clusters", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListKubernetesClusters: func() (*civogo.PaginatedKubernetesClusters, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeKubernetesClusters()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("error listing volumes for cluster", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListKubernetesClusters: func() (*civogo.PaginatedKubernetesClusters, error) {
+				return &civogo.PaginatedKubernetesClusters{
+					Items: []civogo.KubernetesCluster{{ID: "cluster1", Name: "test-cluster1"}},
+				}, nil
+			},
+
+			FnListVolumesForCluster: func(clusterID string) ([]civogo.Volume, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeKubernetesClusters()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("error deleting volume", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListKubernetesClusters: func() (*civogo.PaginatedKubernetesClusters, error) {
+				return &civogo.PaginatedKubernetesClusters{
+					Items: []civogo.KubernetesCluster{{ID: "cluster1", Name: "test-cluster1"}},
+				}, nil
+			},
+
+			FnListVolumesForCluster: func(clusterID string) ([]civogo.Volume, error) {
+				return []civogo.Volume{{ID: "volume1", Name: "test-volume1"}}, nil
+			},
+
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeKubernetesClusters()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("error deleting kubernetes cluster", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListKubernetesClusters: func() (*civogo.PaginatedKubernetesClusters, error) {
+				return &civogo.PaginatedKubernetesClusters{
+					Items: []civogo.KubernetesCluster{{ID: "cluster1", Name: "test-cluster1"}},
+				}, nil
+			},
+
+			FnListVolumesForCluster: func(clusterID string) ([]civogo.Volume, error) {
+				return []civogo.Volume{{ID: "volume1", Name: "test-volume1"}}, nil
+			},
+
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+
+			FnDeleteKubernetesCluster: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeKubernetesClusters()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("error finding network", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListKubernetesClusters: func() (*civogo.PaginatedKubernetesClusters, error) {
+				return &civogo.PaginatedKubernetesClusters{
+					Items: []civogo.KubernetesCluster{{ID: "cluster1", Name: "test-cluster1"}},
+				}, nil
+			},
+
+			FnListVolumesForCluster: func(clusterID string) ([]civogo.Volume, error) {
+				return []civogo.Volume{{ID: "volume1", Name: "test-volume1"}}, nil
+			},
+
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+
+			FnDeleteKubernetesCluster: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+
+			FnFindNetwork: func(search string) (*civogo.Network, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeKubernetesClusters()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("error deleting network", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListKubernetesClusters: func() (*civogo.PaginatedKubernetesClusters, error) {
+				return &civogo.PaginatedKubernetesClusters{
+					Items: []civogo.KubernetesCluster{{ID: "cluster1", Name: "test-cluster1"}},
+				}, nil
+			},
+
+			FnListVolumesForCluster: func(clusterID string) ([]civogo.Volume, error) {
+				return []civogo.Volume{{ID: "volume1", Name: "test-volume1"}}, nil
+			},
+
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+
+			FnDeleteKubernetesCluster: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+
+			FnFindNetwork: func(search string) (*civogo.Network, error) {
+				return &civogo.Network{ID: "network1", Name: "test-network1"}, nil
+			},
+
+			FnDeleteNetwork: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeKubernetesClusters()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+}

--- a/internal/civo/orphans.go
+++ b/internal/civo/orphans.go
@@ -1,0 +1,269 @@
+package civo
+
+import (
+	"fmt"
+
+	"github.com/civo/civogo"
+	"golang.org/x/sync/errgroup"
+)
+
+// NukeOrphanedResources deletes all subresources not in use by a compute
+// instance in the Civo account targeted. It returns an error if the deletion
+// process encounters any issues. The resources targeted by this function are:
+// - Volumes
+// - SSH keys
+// - Networks
+func (c *Civo) NukeOrphanedResources() error {
+	c.logger.Infof("orphaned resources enabled: looking for volumes, SSH keys, and networks not in use by any instances")
+
+	// fetch all nodes first, we'll need them to check for orphaned resources
+	c.logger.Infof("fetching all instances")
+	nodes, err := c.getAllNodes()
+	if err != nil {
+		return fmt.Errorf("unable to fetch nodes: %w", err)
+	}
+
+	c.logger.Infof("found %d instances", len(nodes))
+
+	// fetch orphaned volumes
+	orphanedVolumes, err := c.getOrphanedVolumes()
+	if err != nil {
+		return fmt.Errorf("unable to fetch orphaned volumes: %w", err)
+	}
+
+	// fetch orphaned SSH keys
+	orphanedSSHKeys, err := c.getOrphanedSSHKeys(nodes)
+	if err != nil {
+		return fmt.Errorf("unable to fetch orphaned SSH keys: %w", err)
+	}
+
+	// fetch orphaned networks
+	orphanedNetworks, err := c.getOrphanedNetworks(nodes)
+	if err != nil {
+		return fmt.Errorf("unable to fetch orphaned networks: %w", err)
+	}
+
+	// create parallel executions for deleting orphaned resources
+	eg := errgroup.Group{}
+
+	// delete orphaned volumes
+	eg.Go(func() error {
+		return c.deleteVolumes(orphanedVolumes)
+	})
+
+	// delete orphaned SSH keys
+	eg.Go(func() error {
+		return c.deleteSSHKeys(orphanedSSHKeys)
+	})
+
+	// delete orphaned networks
+	eg.Go(func() error {
+		return c.deleteNetworks(orphanedNetworks)
+	})
+
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("unable to delete orphaned resources: %w", err)
+	}
+
+	return nil
+}
+
+// deleteVolumes deletes all volumes in the provided list. It returns an error
+// if the deletion process encounters any issues.
+func (c *Civo) deleteVolumes(volumes []civogo.Volume) error {
+	for _, volume := range volumes {
+		if !c.nuke {
+			c.logger.Warnf("refusing to delete volume %q: nuke is not enabled", volume.Name)
+			continue
+		}
+
+		c.logger.Infof("deleting volume %q", volume.Name)
+
+		res, err := c.client.DeleteVolume(volume.ID)
+		if err != nil {
+			return fmt.Errorf("unable to delete volume %s: %w", volume.Name, err)
+		}
+
+		if res.ErrorCode != "200" {
+			return fmt.Errorf("Civo returned an error code %q when deleting volume %s: %s", res.ErrorCode, volume.Name, res.ErrorDetails)
+		}
+		c.logger.Infof("deleted volume %s", volume.Name)
+	}
+
+	return nil
+}
+
+// deleteSSHKeys deletes all SSH keys in the provided list. It returns an error
+// if the deletion process encounters any issues.
+func (c *Civo) deleteSSHKeys(keys []civogo.SSHKey) error {
+	for _, key := range keys {
+		if !c.nuke {
+			c.logger.Warnf("refusing to delete SSH key %s: nuke is not enabled", key.Name)
+			continue
+		}
+
+		c.logger.Infof("deleting SSH key %q", key.Name)
+
+		res, err := c.client.DeleteSSHKey(key.ID)
+		if err != nil {
+			return fmt.Errorf("unable to delete SSH key %s: %w", key.Name, err)
+		}
+
+		if res.ErrorCode != "200" {
+			return fmt.Errorf("Civo returned an error code %q when deleting SSH key %s: %s", res.ErrorCode, key.Name, res.ErrorDetails)
+		}
+		c.logger.Infof("deleted SSH key %s", key.Name)
+	}
+
+	return nil
+}
+
+// deleteNetworks deletes all networks in the provided list. It returns an error
+// if the deletion process encounters any issues.
+func (c *Civo) deleteNetworks(networks []civogo.Network) error {
+	for _, network := range networks {
+		if !c.nuke {
+			c.logger.Warnf("refusing to delete network %s: nuke is not enabled", network.Name)
+			continue
+		}
+
+		c.logger.Infof("deleting network %q", network.Name)
+
+		res, err := c.client.DeleteNetwork(network.ID)
+		if err != nil {
+			return fmt.Errorf("unable to delete network %s: %w", network.Name, err)
+		}
+
+		if res.ErrorCode != "200" {
+			return fmt.Errorf("Civo returned an error code %q when deleting network %s: %s", res.ErrorCode, network.Name, res.ErrorDetails)
+		}
+		c.logger.Infof("deleted network %s", network.Name)
+	}
+
+	return nil
+}
+
+// getAllNodes fetches all nodes in the Civo account. Since the results are
+// paginated, this function will fetch all pages of nodes and return them as a
+// single list. It returns an error if the fetching process encounters any
+// issues.
+func (c *Civo) getAllNodes() ([]civogo.Instance, error) {
+	var nodes []civogo.Instance
+
+	perPage := 100
+	for page := 1; ; page++ {
+		c.logger.Infof("listing page %d of nodes", page)
+
+		nodesPage, err := c.client.ListInstances(page, perPage)
+		if err != nil {
+			return nil, fmt.Errorf("unable to list nodes: %w", err)
+		}
+
+		c.logger.Infof("found %d nodes on page %d", len(nodesPage.Items), page)
+		nodes = append(nodes, nodesPage.Items...)
+
+		if nodesPage.Pages == page {
+			break
+		}
+	}
+
+	c.logger.Infof("found %d nodes on all pages", len(nodes))
+	return nodes, nil
+}
+
+// getOrphanedVolumes fetches all volumes that are not attached to any node
+// instance instead of relying if they are referenced by a node instance. It
+// returns an error if the fetching process encounters any issues.
+func (c *Civo) getOrphanedVolumes() ([]civogo.Volume, error) {
+	c.logger.Infof("listing volumes")
+
+	volumes, err := c.client.ListVolumes()
+	if err != nil {
+		return nil, fmt.Errorf("unable to list volumes: %w", err)
+	}
+
+	newVolumeList := make([]civogo.Volume, 0, len(volumes))
+	for _, volume := range volumes {
+		if volume.Status == volumeStatusAttached {
+			c.logger.Warnf("skipping volume %q: it is attached to the node instance with ID %q", volume.Name, volume.InstanceID)
+			continue
+		}
+
+		c.logger.Infof("found orphaned volume (not attached) %q - ID: %q", volume.Name, volume.ID)
+		newVolumeList = append(newVolumeList, volume)
+	}
+
+	return newVolumeList, nil
+}
+
+// getOrphanedSSHKeys fetches all SSH keys then compares them against the
+// provided list of nodes to determine if they are associated with any of
+// them. It returns an error if the fetching process encounters any issues.
+func (c *Civo) getOrphanedSSHKeys(nodes []civogo.Instance) ([]civogo.SSHKey, error) {
+	var keys []civogo.SSHKey
+
+	c.logger.Infof("listing SSH keys")
+
+	keys, err := c.client.ListSSHKeys()
+	if err != nil {
+		return nil, fmt.Errorf("unable to list SSH keys: %w", err)
+	}
+
+	c.logger.Infof("found %d SSH keys", len(keys))
+
+	// iterate over all keys and check if they are associated with any nodes
+	orphanedKeys := make([]civogo.SSHKey, 0, len(keys))
+	for _, key := range keys {
+		var found bool
+
+		// iterate through the nodes finding if they use the current key
+		for _, node := range nodes {
+			if node.SSHKeyID == key.ID {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			c.logger.Infof("found orphaned SSH key %q - ID: %q", key.Name, key.ID)
+			orphanedKeys = append(orphanedKeys, key)
+		}
+	}
+
+	return orphanedKeys, nil
+}
+
+// getOrphanedNetworks fetches all networks then compares them against the
+// provided list of nodes to determine if they are associated with any of
+// them. It returns an error if the fetching process encounters any issues.
+func (c *Civo) getOrphanedNetworks(nodes []civogo.Instance) ([]civogo.Network, error) {
+	c.logger.Infof("listing networks")
+
+	networks, err := c.client.ListNetworks()
+	if err != nil {
+		return nil, fmt.Errorf("unable to list networks: %w", err)
+	}
+
+	c.logger.Infof("found %d networks", len(networks))
+
+	// iterate over all networks and check if they are associated with any nodes
+	orphanedNetworks := make([]civogo.Network, 0, len(networks))
+	for _, network := range networks {
+		var found bool
+
+		// iterate through the nodes finding if they use the current network
+		for _, node := range nodes {
+			if node.NetworkID == network.ID {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			c.logger.Infof("found orphaned network %q - ID: %q", network.Name, network.ID)
+			orphanedNetworks = append(orphanedNetworks, network)
+		}
+	}
+
+	return orphanedNetworks, nil
+}

--- a/internal/civo/ssh_keys.go
+++ b/internal/civo/ssh_keys.go
@@ -1,0 +1,48 @@
+//nolint:dupl // similar functions due to upstream packaging
+package civo
+
+import (
+	"fmt"
+
+	"github.com/konstructio/dropkick/internal/compare"
+	"github.com/konstructio/dropkick/internal/outputwriter"
+)
+
+// NukeSSHKeys deletes all SSH keys associated with the Civo client.
+// It returns an error if the deletion process encounters any issues.
+func (c *Civo) NukeSSHKeys() error {
+	c.logger.Infof("listing SSH keys")
+
+	keys, err := c.client.ListSSHKeys()
+	if err != nil {
+		return fmt.Errorf("unable to list SSH keys: %w", err)
+	}
+
+	c.logger.Infof("found %d SSH keys", len(keys))
+
+	for _, key := range keys {
+		c.logger.Infof("found SSH key %q - ID: %q", key.Name, key.ID)
+
+		if c.nameFilter != "" && !compare.ContainsIgnoreCase(key.Name, c.nameFilter) {
+			c.logger.Warnf("skipping SSH key %q: name does not match filter", key.Name)
+			continue
+		}
+
+		if c.nuke {
+			c.logger.Infof("deleting SSH key %q", key.Name)
+
+			res, err := c.client.DeleteSSHKey(key.ID)
+			if err != nil {
+				return fmt.Errorf("unable to delete SSH key %s: %w", key.Name, err)
+			}
+
+			if res.ErrorCode != "200" {
+				return fmt.Errorf("Civo returned an error code %q when deleting SSH key %s: %s", res.ErrorCode, key.Name, res.ErrorDetails)
+			}
+			outputwriter.WriteStdoutf("deleted SSH key %s", key.Name)
+		} else {
+			c.logger.Warnf("refusing to delete SSH key %s: nuke is not enabled", key.Name)
+		}
+	}
+	return nil
+}

--- a/internal/civo/volumes.go
+++ b/internal/civo/volumes.go
@@ -1,4 +1,3 @@
-//nolint:dupl // similar functions due to upstream packaging
 package civo
 
 import (

--- a/internal/civo/volumes.go
+++ b/internal/civo/volumes.go
@@ -8,6 +8,8 @@ import (
 	"github.com/konstructio/dropkick/internal/outputwriter"
 )
 
+const volumeStatusAttached = "attached"
+
 // NukeVolumes deletes all volumes associated with the Civo client.
 // It returns an error if the deletion process encounters any issues.
 func (c *Civo) NukeVolumes() error {
@@ -21,7 +23,7 @@ func (c *Civo) NukeVolumes() error {
 	c.logger.Infof("found %d volumes", len(volumes))
 
 	for _, volume := range volumes {
-		c.logger.Infof("found volume %q - ID: %q", volume.Name, volume.ID)
+		c.logger.Infof("found volume %q - ID: %q (attached? %v)", volume.Name, volume.ID, volume.Status == volumeStatusAttached)
 
 		if c.nameFilter != "" && !compare.ContainsIgnoreCase(volume.Name, c.nameFilter) {
 			c.logger.Warnf("skipping volume %q: name does not match filter", volume.Name)
@@ -29,6 +31,11 @@ func (c *Civo) NukeVolumes() error {
 		}
 
 		if c.nuke {
+			if volume.Status == volumeStatusAttached {
+				c.logger.Warnf("refusing to delete volume %s: it is attached to the node instance with ID %q", volume.Name, volume.InstanceID)
+				continue
+			}
+
 			c.logger.Infof("deleting volume %q", volume.Name)
 
 			res, err := c.client.DeleteVolume(volume.ID)


### PR DESCRIPTION
## Description

This PR improves Civo Cloud support by:

* Adding support to fetch and delete SSH keys in the account
* Adding support to *only* delete orphaned resources (currently limited to volumes, SSH keys and networks)
  * If enabled, **no other resource is deleted besides the orphaned resources** (so it's mutually exclusive with, say, `--name-contains`)
  * For volumes, we find all volumes not attached to an Instance (where instance can be a Kubernetes node or a compute instance)
  * For SSH keys, we find all nodes, then compare the node list against the list of SSH keys. If a key exists but no node uses it, it's marked for deletion.
  * For Networks, we find all nodes, then compare the node list against the list of Networks. If a network exists but no node uses it, it's marked for deletion.
* Adds unit tests for the Kubernetes part, other tests coming next to reduce the size of this PR 

With orphaned resources you can do either of:

```bash
# delete all resources in nyc1
dropkick --region nyc1 

# only delete resources not tied to an instance in nyc1
dropkick --region nyc1 --orphans-only
```

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
