### PR TITLE
Add firewall support (orphan mode and normal mode). Add unit tests.

### DIFF
--- a/cmd/civo.go
+++ b/cmd/civo.go
@@ -104,5 +104,9 @@ func runCivo(output io.Writer, opts civoOptions, token string) error {
 		return fmt.Errorf("unable to cleanup SSH keys: %w", err)
 	}
 
+	if err := client.NukeFirewalls(); err != nil {
+		return fmt.Errorf("unable to cleanup firewalls: %w", err)
+	}
+
 	return nil
 }

--- a/internal/civo/client_test.go
+++ b/internal/civo/client_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/civo/civogo"
 )
 
+type errNotImplemented struct {
+	funcName string
+}
+
+func (e *errNotImplemented) Error() string {
+	return fmt.Sprintf("%q is not implemented", e.funcName)
+}
+
 type mockCivoClient struct {
 	FnListInstances               func(page int, perPage int) (*civogo.PaginatedInstanceList, error)
 	FnListSSHKeys                 func() ([]civogo.SSHKey, error)
@@ -23,66 +31,144 @@ type mockCivoClient struct {
 	FnDeleteObjectStoreCredential func(id string) (*civogo.SimpleResponse, error)
 	FnListObjectStores            func() (*civogo.PaginatedObjectstores, error)
 	FnDeleteObjectStore           func(id string) (*civogo.SimpleResponse, error)
+	FnListFirewalls               func() ([]civogo.Firewall, error)
+	FnDeleteFirewall              func(id string) (*civogo.SimpleResponse, error)
 }
 
 func (m *mockCivoClient) ListInstances(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+	if m.FnListInstances == nil {
+		return nil, &errNotImplemented{funcName: "ListInstances"}
+	}
+
 	return m.FnListInstances(page, perPage)
 }
 
 func (m *mockCivoClient) ListSSHKeys() ([]civogo.SSHKey, error) {
+	if m.FnListSSHKeys == nil {
+		return nil, &errNotImplemented{funcName: "ListSSHKeys"}
+	}
+
 	return m.FnListSSHKeys()
 }
 
 func (m *mockCivoClient) DeleteSSHKey(id string) (*civogo.SimpleResponse, error) {
+	if m.FnDeleteSSHKey == nil {
+		return nil, &errNotImplemented{funcName: "DeleteSSHKey"}
+	}
+
 	return m.FnDeleteSSHKey(id)
 }
 
 func (m *mockCivoClient) ListVolumes() ([]civogo.Volume, error) {
+	if m.FnListVolumes == nil {
+		return nil, &errNotImplemented{funcName: "ListVolumes"}
+	}
+
 	return m.FnListVolumes()
 }
 
 func (m *mockCivoClient) DeleteVolume(id string) (*civogo.SimpleResponse, error) {
+	if m.FnDeleteVolume == nil {
+		return nil, &errNotImplemented{funcName: "DeleteVolume"}
+	}
+
 	return m.FnDeleteVolume(id)
 }
 
 func (m *mockCivoClient) ListKubernetesClusters() (*civogo.PaginatedKubernetesClusters, error) {
+	if m.FnListKubernetesClusters == nil {
+		return nil, &errNotImplemented{funcName: "ListKubernetesClusters"}
+	}
+
 	return m.FnListKubernetesClusters()
 }
 
 func (m *mockCivoClient) DeleteKubernetesCluster(id string) (*civogo.SimpleResponse, error) {
+	if m.FnDeleteKubernetesCluster == nil {
+		return nil, &errNotImplemented{funcName: "DeleteKubernetesCluster"}
+	}
+
 	return m.FnDeleteKubernetesCluster(id)
 }
 
 func (m *mockCivoClient) ListVolumesForCluster(clusterID string) ([]civogo.Volume, error) {
+	if m.FnListVolumesForCluster == nil {
+		return nil, &errNotImplemented{funcName: "ListVolumesForCluster"}
+	}
+
 	return m.FnListVolumesForCluster(clusterID)
 }
 
 func (m *mockCivoClient) ListNetworks() ([]civogo.Network, error) {
+	if m.FnListNetworks == nil {
+		return nil, &errNotImplemented{funcName: "ListNetworks"}
+	}
+
 	return m.FnListNetworks()
 }
 
 func (m *mockCivoClient) FindNetwork(search string) (*civogo.Network, error) {
+	if m.FnFindNetwork == nil {
+		return nil, &errNotImplemented{funcName: "FindNetwork"}
+	}
+
 	return m.FnFindNetwork(search)
 }
 
 func (m *mockCivoClient) DeleteNetwork(id string) (*civogo.SimpleResponse, error) {
+	if m.FnDeleteNetwork == nil {
+		return nil, &errNotImplemented{funcName: "DeleteNetwork"}
+	}
+
 	return m.FnDeleteNetwork(id)
 }
 
 func (m *mockCivoClient) ListObjectStoreCredentials() (*civogo.PaginatedObjectStoreCredentials, error) {
+	if m.FnListObjectStoreCredentials == nil {
+		return nil, &errNotImplemented{funcName: "ListObjectStoreCredentials"}
+	}
+
 	return m.FnListObjectStoreCredentials()
 }
 
 func (m *mockCivoClient) DeleteObjectStoreCredential(id string) (*civogo.SimpleResponse, error) {
+	if m.FnDeleteObjectStoreCredential == nil {
+		return nil, &errNotImplemented{funcName: "DeleteObjectStoreCredential"}
+	}
+
 	return m.FnDeleteObjectStoreCredential(id)
 }
 
 func (m *mockCivoClient) ListObjectStores() (*civogo.PaginatedObjectstores, error) {
+	if m.FnListObjectStores == nil {
+		return nil, &errNotImplemented{funcName: "ListObjectStores"}
+	}
+
 	return m.FnListObjectStores()
 }
 
 func (m *mockCivoClient) DeleteObjectStore(id string) (*civogo.SimpleResponse, error) {
+	if m.FnDeleteObjectStore == nil {
+		return nil, &errNotImplemented{funcName: "DeleteObjectStore"}
+	}
+
 	return m.FnDeleteObjectStore(id)
+}
+
+func (m *mockCivoClient) ListFirewalls() ([]civogo.Firewall, error) {
+	if m.FnListFirewalls == nil {
+		return nil, &errNotImplemented{funcName: "ListFirewalls"}
+	}
+
+	return m.FnListFirewalls()
+}
+
+func (m *mockCivoClient) DeleteFirewall(id string) (*civogo.SimpleResponse, error) {
+	if m.FnDeleteFirewall == nil {
+		return nil, &errNotImplemented{funcName: "DeleteFirewall"}
+	}
+
+	return m.FnDeleteFirewall(id)
 }
 
 type mockLogger struct {

--- a/internal/civo/firewalls.go
+++ b/internal/civo/firewalls.go
@@ -1,3 +1,4 @@
+//nolint:dupl // similar functions due to upstream packaging
 package civo
 
 import (

--- a/internal/civo/firewalls.go
+++ b/internal/civo/firewalls.go
@@ -1,0 +1,48 @@
+package civo
+
+import (
+	"fmt"
+
+	"github.com/konstructio/dropkick/internal/compare"
+	"github.com/konstructio/dropkick/internal/outputwriter"
+)
+
+// NukeFirewalls deletes all firewalls associated with the Civo client.
+// It returns an error if the deletion process encounters any issues.
+func (c *Civo) NukeFirewalls() error {
+	c.logger.Infof("listing firewalls")
+
+	firewalls, err := c.client.ListFirewalls()
+	if err != nil {
+		return fmt.Errorf("unable to list firewalls: %w", err)
+	}
+
+	c.logger.Infof("found %d firewalls", len(firewalls))
+
+	for _, firewall := range firewalls {
+		c.logger.Infof("found firewall: name: %q - ID: %q", firewall.Name, firewall.ID)
+
+		if c.nameFilter != "" && !compare.ContainsIgnoreCase(firewall.Name, c.nameFilter) {
+			c.logger.Warnf("skipping firewall %q: name does not match filter", firewall.Name)
+			continue
+		}
+
+		if c.nuke {
+			c.logger.Infof("deleting firewall %q", firewall.Name)
+			res, err := c.client.DeleteFirewall(firewall.ID)
+			if err != nil {
+				return fmt.Errorf("unable to delete firewall %q: %w", firewall.Name, err)
+			}
+
+			if res.ErrorCode != "200" {
+				return fmt.Errorf("Civo returned an error code %q when deleting firewall %q: %s", res.ErrorCode, firewall.Name, res.ErrorDetails)
+			}
+
+			outputwriter.WriteStdoutf("deleted firewall %q", firewall.Name)
+		} else {
+			c.logger.Warnf("refusing to delete firewall %q: nuke is not enabled", firewall.Name)
+		}
+	}
+
+	return nil
+}

--- a/internal/civo/firewalls_test.go
+++ b/internal/civo/firewalls_test.go
@@ -1,0 +1,140 @@
+package civo
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/civo/civogo"
+)
+
+func TestNukeFirewalls(t *testing.T) {
+	t.Run("successfully list and delete firewalls", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return []civogo.Firewall{
+					{ID: "firewall1", Name: "test-firewall1"},
+				}, nil
+			},
+			FnDeleteFirewall: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeFirewalls()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+
+	t.Run("error listing firewalls", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeFirewalls()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("error deleting firewall", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return []civogo.Firewall{
+					{ID: "firewall1", Name: "test-firewall1"},
+				}, nil
+			},
+			FnDeleteFirewall: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       true,
+		}
+
+		err := c.NukeFirewalls()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("skipping firewall due to name filter", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return []civogo.Firewall{
+					{ID: "firewall1", Name: "test-firewall1"},
+				}, nil
+			},
+			FnDeleteFirewall: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "non-matching-filter",
+			nuke:       true,
+		}
+
+		err := c.NukeFirewalls()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+
+	t.Run("nuke is not enabled, refuse to delete", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return []civogo.Firewall{
+					{ID: "firewall1", Name: "test-firewall1"},
+				}, nil
+			},
+		}
+
+		c := &Civo{
+			client:     mockClient,
+			logger:     &mockLogger{os.Stderr},
+			nameFilter: "",
+			nuke:       false,
+		}
+
+		err := c.NukeFirewalls()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+}

--- a/internal/civo/orphans_test.go
+++ b/internal/civo/orphans_test.go
@@ -1,0 +1,1136 @@
+package civo
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/civo/civogo"
+)
+
+func TestDeleteVolumes(t *testing.T) {
+	t.Run("successfully delete volumes", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		volumes := []civogo.Volume{{ID: "volume1", Name: "test-volume1"}}
+
+		err := c.deleteVolumes(volumes)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+
+	t.Run("error deleting volume", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		volumes := []civogo.Volume{{ID: "volume1", Name: "test-volume1"}}
+
+		err := c.deleteVolumes(volumes)
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("nuke not enabled", func(tt *testing.T) {
+		mockClient := &mockCivoClient{}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   false,
+		}
+
+		volumes := []civogo.Volume{{ID: "volume1", Name: "test-volume1"}}
+
+		err := c.deleteVolumes(volumes)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+}
+
+func TestDeleteSSHKeys(t *testing.T) {
+	t.Run("successfully delete SSH keys", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnDeleteSSHKey: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		keys := []civogo.SSHKey{{ID: "key1", Name: "test-key1"}}
+
+		err := c.deleteSSHKeys(keys)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+
+	t.Run("error deleting SSH key", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnDeleteSSHKey: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		keys := []civogo.SSHKey{{ID: "key1", Name: "test-key1"}}
+
+		err := c.deleteSSHKeys(keys)
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("nuke not enabled", func(tt *testing.T) {
+		mockClient := &mockCivoClient{}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   false,
+		}
+
+		keys := []civogo.SSHKey{{ID: "key1", Name: "test-key1"}}
+
+		err := c.deleteSSHKeys(keys)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+}
+
+func TestDeleteNetworks(t *testing.T) {
+	t.Run("successfully delete networks", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnDeleteNetwork: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		networks := []civogo.Network{{ID: "network1", Name: "test-network1"}}
+
+		err := c.deleteNetworks(networks)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+
+	t.Run("error deleting network", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnDeleteNetwork: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		networks := []civogo.Network{{ID: "network1", Name: "test-network1"}}
+
+		err := c.deleteNetworks(networks)
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("nuke not enabled", func(tt *testing.T) {
+		mockClient := &mockCivoClient{}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   false,
+		}
+
+		networks := []civogo.Network{{ID: "network1", Name: "test-network1"}}
+
+		err := c.deleteNetworks(networks)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+}
+
+func TestDeleteFirewalls(t *testing.T) {
+	t.Run("successfully delete firewalls", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnDeleteFirewall: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		firewalls := []*civogo.Firewall{{ID: "firewall1", Name: "test-firewall1"}}
+
+		err := c.deleteFirewalls(firewalls)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+
+	t.Run("error deleting firewall", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnDeleteFirewall: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		firewalls := []*civogo.Firewall{{ID: "firewall1", Name: "test-firewall1"}}
+
+		err := c.deleteFirewalls(firewalls)
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("nuke not enabled", func(tt *testing.T) {
+		mockClient := &mockCivoClient{}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   false,
+		}
+
+		firewalls := []*civogo.Firewall{{ID: "firewall1", Name: "test-firewall1"}}
+
+		err := c.deleteFirewalls(firewalls)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+}
+
+func TestGetAllNodes(t *testing.T) {
+	t.Run("successfully list all nodes from multiple pages", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				if page == 1 {
+					return &civogo.PaginatedInstanceList{
+						Items: []civogo.Instance{
+							{ID: "node1", Hostname: "node-1"},
+							{ID: "node2", Hostname: "node-2"},
+						},
+						Pages: 2,
+					}, nil
+				}
+				if page == 2 {
+					return &civogo.PaginatedInstanceList{
+						Items: []civogo.Instance{
+							{ID: "node3", Hostname: "node-3"},
+						},
+						Pages: 2,
+					}, nil
+				}
+				return nil, errors.New("invalid page number")
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		nodes, err := c.getAllNodes()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(nodes) != 3 {
+			tt.Errorf("expected 3 nodes, got %d", len(nodes))
+		}
+
+		if nodes[0].ID != "node1" || nodes[1].ID != "node2" || nodes[2].ID != "node3" {
+			tt.Errorf("unexpected node IDs: %v", nodes)
+		}
+	})
+
+	t.Run("error listing nodes on first page", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				if page == 1 {
+					return nil, errTest
+				}
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", Hostname: "node-1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		_, err := c.getAllNodes()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("successfully list nodes when only one page exists", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				if page == 1 {
+					return &civogo.PaginatedInstanceList{
+						Items: []civogo.Instance{
+							{ID: "node1", Hostname: "node-1"},
+							{ID: "node2", Hostname: "node-2"},
+						},
+						Pages: 1,
+					}, nil
+				}
+				return nil, errors.New("invalid page number")
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		nodes, err := c.getAllNodes()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(nodes) != 2 {
+			tt.Errorf("expected 2 nodes, got %d", len(nodes))
+		}
+	})
+}
+
+func TestGetOrphanedVolumes(t *testing.T) {
+	t.Run("successfully fetch orphaned volumes", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListVolumes: func() ([]civogo.Volume, error) {
+				return []civogo.Volume{
+					{ID: "volume1", Name: "orphan-volume1", Status: "available"},
+					{ID: "volume2", Name: "attached-volume", Status: volumeStatusAttached, InstanceID: "node1"},
+					{ID: "volume3", Name: "orphan-volume2", Status: "available"},
+				}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		volumes, err := c.getOrphanedVolumes()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(volumes) != 2 {
+			tt.Errorf("expected 2 orphaned volumes, got %d", len(volumes))
+		}
+
+		if volumes[0].ID != "volume1" || volumes[1].ID != "volume3" {
+			tt.Errorf("unexpected orphaned volumes: %v", volumes)
+		}
+	})
+
+	t.Run("error listing volumes", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListVolumes: func() ([]civogo.Volume, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		_, err := c.getOrphanedVolumes()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("no orphaned volumes", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListVolumes: func() ([]civogo.Volume, error) {
+				return []civogo.Volume{
+					{ID: "volume1", Name: "attached-volume1", Status: volumeStatusAttached, InstanceID: "node1"},
+				}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		volumes, err := c.getOrphanedVolumes()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(volumes) != 0 {
+			tt.Errorf("expected 0 orphaned volumes, got %d", len(volumes))
+		}
+	})
+}
+
+func TestGetOrphanedSSHKeys(t *testing.T) {
+	t.Run("successfully fetch orphaned SSH keys", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListSSHKeys: func() ([]civogo.SSHKey, error) {
+				return []civogo.SSHKey{
+					{ID: "key1", Name: "key1"},
+					{ID: "key2", Name: "key2"},
+					{ID: "key3", Name: "key3"},
+				}, nil
+			},
+		}
+
+		nodes := []civogo.Instance{
+			{ID: "node1", SSHKeyID: "key1"},
+			{ID: "node2", SSHKeyID: "key2"},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		orphanedKeys, err := c.getOrphanedSSHKeys(nodes)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(orphanedKeys) != 1 {
+			tt.Errorf("expected 1 orphaned SSH key, got %d", len(orphanedKeys))
+		}
+
+		if orphanedKeys[0].ID != "key3" {
+			tt.Errorf("unexpected orphaned SSH key: %v", orphanedKeys[0])
+		}
+	})
+
+	t.Run("error listing SSH keys", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListSSHKeys: func() ([]civogo.SSHKey, error) {
+				return nil, errTest
+			},
+		}
+
+		nodes := []civogo.Instance{
+			{ID: "node1", SSHKeyID: "key1"},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		_, err := c.getOrphanedSSHKeys(nodes)
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("no orphaned SSH keys", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListSSHKeys: func() ([]civogo.SSHKey, error) {
+				return []civogo.SSHKey{
+					{ID: "key1", Name: "key1"},
+					{ID: "key2", Name: "key2"},
+				}, nil
+			},
+		}
+
+		nodes := []civogo.Instance{
+			{ID: "node1", SSHKeyID: "key1"},
+			{ID: "node2", SSHKeyID: "key2"},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		orphanedKeys, err := c.getOrphanedSSHKeys(nodes)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(orphanedKeys) != 0 {
+			tt.Errorf("expected 0 orphaned SSH keys, got %d", len(orphanedKeys))
+		}
+	})
+}
+
+func TestGetOrphanedNetworks(t *testing.T) {
+	t.Run("successfully fetch orphaned networks", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListNetworks: func() ([]civogo.Network, error) {
+				return []civogo.Network{
+					{ID: "network1", Name: "network1"},
+					{ID: "network2", Name: "network2"},
+					{ID: "network3", Name: "network3"},
+				}, nil
+			},
+		}
+
+		nodes := []civogo.Instance{
+			{ID: "node1", NetworkID: "network1"},
+			{ID: "node2", NetworkID: "network2"},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		orphanedNetworks, err := c.getOrphanedNetworks(nodes)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(orphanedNetworks) != 1 {
+			tt.Errorf("expected 1 orphaned network, got %d", len(orphanedNetworks))
+		}
+
+		if orphanedNetworks[0].ID != "network3" {
+			tt.Errorf("unexpected orphaned network: %v", orphanedNetworks[0])
+		}
+	})
+
+	t.Run("error listing networks", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListNetworks: func() ([]civogo.Network, error) {
+				return nil, errTest
+			},
+		}
+
+		nodes := []civogo.Instance{
+			{ID: "node1", NetworkID: "network1"},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		_, err := c.getOrphanedNetworks(nodes)
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("no orphaned networks", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListNetworks: func() ([]civogo.Network, error) {
+				return []civogo.Network{
+					{ID: "network1", Name: "network1"},
+					{ID: "network2", Name: "network2"},
+				}, nil
+			},
+		}
+
+		nodes := []civogo.Instance{
+			{ID: "node1", NetworkID: "network1"},
+			{ID: "node2", NetworkID: "network2"},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		orphanedNetworks, err := c.getOrphanedNetworks(nodes)
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(orphanedNetworks) != 0 {
+			tt.Errorf("expected 0 orphaned networks, got %d", len(orphanedNetworks))
+		}
+	})
+}
+
+func TestGetOrphanedFirewalls(t *testing.T) {
+	t.Run("successfully fetch orphaned firewalls", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return []civogo.Firewall{
+					{ID: "firewall1", Name: "firewall1", ClusterCount: 0, InstanceCount: 0, LoadBalancerCount: 0},
+					{ID: "firewall2", Name: "firewall2", ClusterCount: 1, InstanceCount: 0, LoadBalancerCount: 0},
+					{ID: "firewall3", Name: "firewall3", ClusterCount: 0, InstanceCount: 0, LoadBalancerCount: 0},
+				}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		orphanedFirewalls, err := c.getOrphanedFirewalls()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(orphanedFirewalls) != 2 {
+			tt.Errorf("expected 2 orphaned firewalls, got %d", len(orphanedFirewalls))
+		}
+
+		if orphanedFirewalls[0].ID != "firewall1" || orphanedFirewalls[1].ID != "firewall3" {
+			tt.Errorf("unexpected orphaned firewalls: %v", orphanedFirewalls)
+		}
+	})
+
+	t.Run("error listing firewalls", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		_, err := c.getOrphanedFirewalls()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	t.Run("no orphaned firewalls", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return []civogo.Firewall{
+					{ID: "firewall1", Name: "firewall1", ClusterCount: 1, InstanceCount: 0, LoadBalancerCount: 0},
+					{ID: "firewall2", Name: "firewall2", ClusterCount: 0, InstanceCount: 1, LoadBalancerCount: 0},
+				}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		orphanedFirewalls, err := c.getOrphanedFirewalls()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+
+		if len(orphanedFirewalls) != 0 {
+			tt.Errorf("expected 0 orphaned firewalls, got %d", len(orphanedFirewalls))
+		}
+	})
+}
+
+// -----------------------------------------------------------------------------
+
+func TestNukeOrphanedResources(t *testing.T) {
+	// Test case for successfully nuking all orphaned resources
+	t.Run("successfully nukes all orphaned resources", func(tt *testing.T) {
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListVolumes: func() ([]civogo.Volume, error) {
+				return []civogo.Volume{
+					{ID: "volume1", Name: "orphan-volume1", Status: "available"},
+				}, nil
+			},
+			FnListSSHKeys: func() ([]civogo.SSHKey, error) {
+				return []civogo.SSHKey{
+					{ID: "key1", Name: "key1"},
+					{ID: "key2", Name: "orphan-key2"},
+				}, nil
+			},
+			FnListNetworks: func() ([]civogo.Network, error) {
+				return []civogo.Network{
+					{ID: "network1", Name: "network1"},
+					{ID: "network2", Name: "orphan-network2"},
+				}, nil
+			},
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return []civogo.Firewall{
+					{ID: "firewall1", Name: "orphan-firewall1", ClusterCount: 0, InstanceCount: 0, LoadBalancerCount: 0},
+				}, nil
+			},
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+			FnDeleteSSHKey: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+			FnDeleteNetwork: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+			FnDeleteFirewall: func(id string) (*civogo.SimpleResponse, error) {
+				return &civogo.SimpleResponse{ErrorCode: "200"}, nil
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		err := c.NukeOrphanedResources()
+		if err != nil {
+			tt.Errorf("expected error to be nil, got %v", err)
+		}
+	})
+
+	// Test case where fetching nodes returns an error
+	t.Run("error fetching nodes", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	// Test case where fetching orphaned volumes returns an error
+	t.Run("error fetching orphaned volumes", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListSSHKeys:   func() ([]civogo.SSHKey, error) { return nil, nil },
+			FnListNetworks:  func() ([]civogo.Network, error) { return nil, nil },
+			FnListFirewalls: func() ([]civogo.Firewall, error) { return nil, nil },
+			FnListVolumes: func() ([]civogo.Volume, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	// Test case where deleting orphaned volumes returns an error
+	t.Run("error deleting orphaned volumes", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListVolumes: func() ([]civogo.Volume, error) {
+				return []civogo.Volume{
+					{ID: "volume1", Name: "orphan-volume1", Status: "available"},
+				}, nil
+			},
+			FnListSSHKeys:   func() ([]civogo.SSHKey, error) { return nil, nil },
+			FnListNetworks:  func() ([]civogo.Network, error) { return nil, nil },
+			FnListFirewalls: func() ([]civogo.Firewall, error) { return nil, nil },
+			FnDeleteVolume: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	// Test case where fetching orphaned SSH keys returns an error
+	t.Run("error fetching orphaned SSH keys", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListVolumes:   func() ([]civogo.Volume, error) { return nil, nil },
+			FnListNetworks:  func() ([]civogo.Network, error) { return nil, nil },
+			FnListFirewalls: func() ([]civogo.Firewall, error) { return nil, nil },
+			FnListSSHKeys: func() ([]civogo.SSHKey, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	// Test case where deleting orphaned SSH keys returns an error
+	t.Run("error deleting orphaned SSH keys", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListVolumes:   func() ([]civogo.Volume, error) { return nil, nil },
+			FnListNetworks:  func() ([]civogo.Network, error) { return nil, nil },
+			FnListFirewalls: func() ([]civogo.Firewall, error) { return nil, nil },
+			FnListSSHKeys: func() ([]civogo.SSHKey, error) {
+				return []civogo.SSHKey{
+					{ID: "key1", Name: "key1"},
+					{ID: "key2", Name: "orphan-key2"},
+				}, nil
+			},
+			FnDeleteSSHKey: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	// Test case where fetching orphaned networks returns an error
+	t.Run("error fetching orphaned networks", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListVolumes: func() ([]civogo.Volume, error) { return nil, nil },
+			FnListSSHKeys: func() ([]civogo.SSHKey, error) { return nil, nil },
+			FnListNetworks: func() ([]civogo.Network, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	// Test case where deleting orphaned networks returns an error
+	t.Run("error deleting orphaned networks", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListVolumes:   func() ([]civogo.Volume, error) { return nil, nil },
+			FnListSSHKeys:   func() ([]civogo.SSHKey, error) { return nil, nil },
+			FnListFirewalls: func() ([]civogo.Firewall, error) { return nil, nil },
+			FnListNetworks: func() ([]civogo.Network, error) {
+				return []civogo.Network{
+					{ID: "network1", Name: "network1"},
+					{ID: "network2", Name: "orphan-network2"},
+				}, nil
+			},
+			FnDeleteNetwork: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	// Test case where fetching orphaned firewalls returns an error
+	t.Run("error fetching orphaned firewalls", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListVolumes:  func() ([]civogo.Volume, error) { return nil, nil },
+			FnListSSHKeys:  func() ([]civogo.SSHKey, error) { return nil, nil },
+			FnListNetworks: func() ([]civogo.Network, error) { return nil, nil },
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+
+	// Test case where deleting orphaned firewalls returns an error
+	t.Run("error deleting orphaned firewalls", func(tt *testing.T) {
+		errTest := errors.New("test error")
+
+		mockClient := &mockCivoClient{
+			FnListInstances: func(page int, perPage int) (*civogo.PaginatedInstanceList, error) {
+				return &civogo.PaginatedInstanceList{
+					Items: []civogo.Instance{
+						{ID: "node1", SSHKeyID: "key1", NetworkID: "network1"},
+					},
+					Pages: 1,
+				}, nil
+			},
+			FnListVolumes:  func() ([]civogo.Volume, error) { return nil, nil },
+			FnListSSHKeys:  func() ([]civogo.SSHKey, error) { return nil, nil },
+			FnListNetworks: func() ([]civogo.Network, error) { return nil, nil },
+			FnListFirewalls: func() ([]civogo.Firewall, error) {
+				return []civogo.Firewall{
+					{ID: "firewall1", Name: "orphan-firewall1", ClusterCount: 0, InstanceCount: 0, LoadBalancerCount: 0},
+				}, nil
+			},
+			FnDeleteFirewall: func(id string) (*civogo.SimpleResponse, error) {
+				return nil, errTest
+			},
+		}
+
+		c := &Civo{
+			client: mockClient,
+			logger: &mockLogger{os.Stderr},
+			nuke:   true,
+		}
+
+		err := c.NukeOrphanedResources()
+		if err == nil {
+			tt.Errorf("expected error to be %v, got nil", errTest)
+		}
+
+		if !errors.Is(err, errTest) {
+			tt.Errorf("expected error to be %v, got %v", errTest, err)
+		}
+	})
+}


### PR DESCRIPTION
## Description

This PR:

* Adds support for firewall checks. Each firewall has a few parameters in the API that show how many other resources depend on it (see below)
* Adds unit tests for pretty much every possible combination
* Makes orphan deletions sequential instead of parallel for easy reading of the output

To verify a firewall is "orphan", we get the count in use for `instance`, `cluster`, and `loadbalancer`. If all 3 are zero, then it's a leftover.

```json
  {
    "id": "415164c0-40ab-4ee5-b92e-768b93bcbcb0",
    "name": "example-a211-9e20a7",
    "account_id": "96eda81a-7a36-4a89-ad4a-69ae28e216a5",
    "rules_count": 6,
    "instance_count": 0,
    "cluster_count": 0,
    "loadbalancer_count": 0,
    "default": "false",
    "label": "",
    "network_id": "464ff5e7-9807-430b-8e1c-22c12414382c",
    "rules": []
  },
```

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
