### PR TITLE
refactor(digitalocean): Pass context as argument

### DIFF
--- a/internal/civo/client_test.go
+++ b/internal/civo/client_test.go
@@ -123,7 +123,6 @@ func TestNew(t *testing.T) {
 		Opts       []Option
 		Token      string
 		Region     string
-		Context    context.Context
 		Logger     *logger.Logger
 		Nuke       bool
 		NameFilter string
@@ -133,7 +132,6 @@ func TestNew(t *testing.T) {
 			Name:       "all good",
 			Token:      "token",
 			Region:     "region",
-			Context:    context.Background(),
 			Logger:     logger.None,
 			Nuke:       true,
 			NameFilter: "filter",
@@ -160,11 +158,10 @@ func TestNew(t *testing.T) {
 			WantErr: true,
 		},
 		{
-			Name:    "missing context",
-			Token:   "token",
-			Region:  "region",
-			Context: nil,
-			Logger:  nil,
+			Name:   "missing context",
+			Token:  "token",
+			Region: "region",
+			Logger: nil,
 		},
 		{
 			Name:    "default logger",

--- a/internal/digitalocean/client.go
+++ b/internal/digitalocean/client.go
@@ -15,15 +15,14 @@ import (
 
 // DigitalOcean is a client for the DigitalOcean API.
 type DigitalOcean struct {
-	client          *godo.Client    // The underlying DigitalOcean API client.
-	s3svc           *s3.S3          // The underlying DigitalOcean Spaces API client.
-	context         context.Context // The context for API requests.
-	nuke            bool            // Whether to nuke resources.
-	token           string          // The API token.
-	logger          *logger.Logger  // The logger instance.
-	spacesAccessKey string          // The access key for Spaces.
-	spacesSecretKey string          // The secret key for Spaces.
-	spacesRegion    string          // The region for Spaces.
+	client          *godo.Client   // The underlying DigitalOcean API client.
+	s3svc           *s3.S3         // The underlying DigitalOcean Spaces API client.
+	nuke            bool           // Whether to nuke resources.
+	token           string         // The API token.
+	logger          *logger.Logger // The logger instance.
+	spacesAccessKey string         // The access key for Spaces.
+	spacesSecretKey string         // The secret key for Spaces.
+	spacesRegion    string         // The region for Spaces.
 }
 
 // Option is a function that configures a DigitalOcean.
@@ -53,14 +52,6 @@ func WithNuke(nuke bool) Option {
 	}
 }
 
-// WithContext sets the context for a DigitalOcean.
-func WithContext(ctx context.Context) Option {
-	return func(c *DigitalOcean) error {
-		c.context = ctx
-		return nil
-	}
-}
-
 func WithS3Storage(accessKey, secretKey, region string) Option {
 	return func(c *DigitalOcean) error {
 		c.spacesAccessKey = accessKey
@@ -73,7 +64,7 @@ func WithS3Storage(accessKey, secretKey, region string) Option {
 // New creates a new DigitalOcean with the given options.
 // It returns an error if the token or region is not set, or if it fails to
 // create the underlying DigitalOcean API client.
-func New(opts ...Option) (*DigitalOcean, error) {
+func New(ctx context.Context, opts ...Option) (*DigitalOcean, error) {
 	c := &DigitalOcean{}
 
 	for _, opt := range opts {
@@ -89,16 +80,12 @@ func New(opts ...Option) (*DigitalOcean, error) {
 	// The DigitalOcean API client does not authenticate until a request is made,
 	// so we're requesting the account but not using it to verify the token.
 	godoClient := godo.NewFromToken(c.token)
-	_, _, err := godoClient.Account.Get(c.context)
+	_, _, err := godoClient.Account.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to authenticate DigitalOcean client: %w", err)
 	}
 
 	c.client = godoClient
-
-	if c.context == nil {
-		c.context = context.Background()
-	}
 
 	// Set up S3 storage
 	if c.spacesAccessKey == "" || c.spacesSecretKey == "" || c.spacesRegion == "" {

--- a/internal/digitalocean/volumes.go
+++ b/internal/digitalocean/volumes.go
@@ -1,16 +1,17 @@
 package digitalocean
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/digitalocean/godo"
 	"github.com/konstructio/dropkick/internal/outputwriter"
 )
 
-func (d *DigitalOcean) NukeVolumes() error {
+func (d *DigitalOcean) NukeVolumes(ctx context.Context) error {
 	d.logger.Infof("listing volumes")
 
-	volumes, _, err := d.client.Storage.ListVolumes(d.context, &godo.ListVolumeParams{})
+	volumes, _, err := d.client.Storage.ListVolumes(ctx, &godo.ListVolumeParams{})
 	if err != nil {
 		return fmt.Errorf("unable to list volumes: %w", err)
 	}
@@ -22,7 +23,7 @@ func (d *DigitalOcean) NukeVolumes() error {
 
 		if d.nuke {
 			d.logger.Infof("deleting volume %q", volume.ID)
-			_, err := d.client.Storage.DeleteVolume(d.context, volume.ID)
+			_, err := d.client.Storage.DeleteVolume(ctx, volume.ID)
 			if err != nil {
 				return fmt.Errorf("unable to delete volume %s: %w", volume.ID, err)
 			}


### PR DESCRIPTION
## Description
Pass `context` as an argument instead of storing it as a field.

By convention, context should be used for propagation (of deadlines, cancellations, etc.), and not stored as a field. Please refer to the article: https://go.dev/blog/context-and-structs

## Related Issue(s)
Fixes #21

## How to test
`digitalocean` subcommand should work as usual.
