### PR TITLE
adds version command for dropkick

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ func Execute() {
 	// Add subcommands
 	rootCmd.AddCommand(getCivoCommand())
 	rootCmd.AddCommand(getDigitalOceanCommand())
+	rootCmd.AddCommand(getVersionCommand())
 
 	// Configure a global flag for "--quiet"
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "suppress output from processing while keeping deletion messages to stdout")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,7 +15,6 @@ func getVersionCommand() *cobra.Command {
 		Short: "print the version for dropkick cli",
 		Long:  `print the version for dropkick cli`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-
 			log := logger.New(io.Writer(os.Stdout))
 
 			log.Infof("dropkick cli version: %q", configs.Version)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/konstructio/dropkick/configs"
+	"github.com/konstructio/dropkick/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+func getVersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "print the version for dropkick cli",
+		Long:  `print the version for dropkick cli`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			log := logger.New(io.Writer(os.Stdout))
+
+			log.Infof("dropkick cli version: %q", configs.Version)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,7 +14,7 @@ func getVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "print the version for dropkick cli",
 		Long:  `print the version for dropkick cli`,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 
 			log := logger.New(io.Writer(os.Stdout))
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,7 +14,7 @@ func getVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "print the version for dropkick cli",
 		Long:  `print the version for dropkick cli`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 
 			log := logger.New(io.Writer(os.Stdout))
 

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -1,0 +1,12 @@
+package configs
+
+const (
+	DefaultVersion = "development"
+)
+
+//nolint:gochecknoglobals // used to store the version of the built binary
+var Version = DefaultVersion
+
+type Config struct {
+	Version string
+}

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -1,12 +1,3 @@
 package configs
 
-const (
-	DefaultVersion = "development"
-)
-
-//nolint:gochecknoglobals // used to store the version of the built binary
-var Version = DefaultVersion
-
-type Config struct {
-	Version string
-}
+var Version = "development"


### PR DESCRIPTION
## Description
adds a version command to dropkick

## How to test
```
go run . version
go build -ldflags "-X github.com/konstructio/dropkick/configs.Version=v0.0.1" -o tmp/dropkick .
./tmp/dropkick version
```
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/1d8b618f-f970-4df9-806b-54c360d5917a">
